### PR TITLE
Create design issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -1,0 +1,16 @@
+---
+name: Design
+about: Track or request design work
+title: 'Design [...] so that [...].'
+labels: design
+assignees: '@gissoo'
+
+---
+
+_This issue tracks design work through the [CDH design review workflow](https://princeton-cdh.github.io/docs/workflows/#workflow-5)._
+
+**Figma links**
+[desktop]() / [tablet]() / [mobile]()
+
+**Additional context**
+Add any other context or screenshots about the design here.

--- a/.github/ISSUE_TEMPLATE/design.md
+++ b/.github/ISSUE_TEMPLATE/design.md
@@ -2,15 +2,11 @@
 name: Design
 about: Track or request design work
 title: 'Design [...] so that [...].'
-labels: design
-assignees: '@gissoo'
+labels: 🗺️ design
 
 ---
 
 _This issue tracks design work through the [CDH design review workflow](https://princeton-cdh.github.io/docs/workflows/#workflow-5)._
-
-**Figma links**
-[desktop]() / [tablet]() / [mobile]()
 
 **Additional context**
 Add any other context or screenshots about the design here.


### PR DESCRIPTION
this is just an idea based on the other templates we currently have; I hope it can be a starting point for discussion. some other ideas:

- should we have separate templates for UX/UI design?
- should the issue template be called "design review" or similar, instead of just "design"?
- what other content would be helpful for the body of the issue template?
- is there any other useful documentation to link to? I added a link to the design review workflow on the dev/design site.

@gissoo this can be whatever you want it to be - whatever we think is most useful for us to help us with our current workflows.